### PR TITLE
Feature/spark bump to 2.1.1

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -11,7 +11,13 @@ RUN cd /usr/lib && tar -zxvf spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.
 RUN mv /usr/lib/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} /usr/lib/spark && rm -fr /usr/lib/spark/examples
 
 #Add hadoop s3 support
-RUN curl "https://search.maven.org/remotecontent?filepath=org/apache/hadoop/hadoop-aws/2.7.3/hadoop-aws-2.7.3.jar" -o /usr/lib/spark/jars/hadoop-aws-2.7.3.jar && curl "https://search.maven.org/remotecontent?filepath=com/amazonaws/aws-java-sdk/1.7.4/aws-java-sdk-1.7.4.jar" -o /usr/lib/spark/jars/aws-java-sdk-1.7.4.jar
+RUN \
+  curl \
+    "https://search.maven.org/remotecontent?filepath=org/apache/hadoop/hadoop-aws/2.8.1/hadoop-aws-2.8.1.jar" \
+    -o /usr/lib/spark/jars/hadoop-aws-2.8.1.jar && \
+  curl \
+    "https://search.maven.org/remotecontent?filepath=com/amazonaws/aws-java-sdk/1.11.152/aws-java-sdk-1.11.152.jar" \
+    -o /usr/lib/spark/jars/aws-java-sdk-1.11.152.jar
 
 ENV SPARK_HOME /usr/lib/spark
 ENV PATH $PATH:/usr/lib/spark/bin

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-jdk
 
-MAINTAINER Luis David Barrios Alfonso (luisdavid.barrios@agsnasoft.com / cyberluisda@gmail.com)
+MAINTAINER Luis David Barrios Alfonso (cyberluisda@gmail.com)
 
 
 ENV SPARK_VERSION 2.1.1

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -3,7 +3,7 @@ FROM openjdk:8-jdk
 MAINTAINER Luis David Barrios Alfonso (luisdavid.barrios@agsnasoft.com / cyberluisda@gmail.com)
 
 
-ENV SPARK_VERSION 2.1.0
+ENV SPARK_VERSION 2.1.1
 ENV HADOOP_VERSION 2.7
 #ADD http://apache.rediris.es/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz /usr/lib
 ADD http://mirrors.ocf.berkeley.edu/apache/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz /usr/lib

--- a/images/connectors/Dockerfile
+++ b/images/connectors/Dockerfile
@@ -1,6 +1,6 @@
 FROM cyberluisda/spark:2.1.1
 
-MAINTAINER Luis David Barrios Alfonso (luisdavid.barrios@agsnasoft.com / cyberluisda@gmail.com)
+MAINTAINER Luis David Barrios Alfonso (cyberluisda@gmail.com)
 
 #add spark extra  libs
 RUN mkdir -p /usr/lib/spark/third

--- a/images/connectors/Dockerfile
+++ b/images/connectors/Dockerfile
@@ -1,4 +1,4 @@
-FROM cyberluisda/spark:2.1
+FROM cyberluisda/spark:2.1.1
 
 MAINTAINER Luis David Barrios Alfonso (luisdavid.barrios@agsnasoft.com / cyberluisda@gmail.com)
 

--- a/images/connectors/files/ivy.xml
+++ b/images/connectors/files/ivy.xml
@@ -2,7 +2,8 @@
     <info organisation="com.ericsson.ivi" module="jobserver-deps"/>
     <configurations defaultconfmapping="default"/>
     <dependencies>
-        <dependency org="org.elasticsearch" name="elasticsearch-spark-20_2.11" rev="5.1.1" />
+        <!-- Elastic search connector is not compatible with spark 2.1.1 -->
+        <!-- dependency org="org.elasticsearch" name="elasticsearch-spark-20_2.11" rev="5.1.1" / -->
         <dependency org="org.apache.spark" name="spark-streaming-kafka-0-10_2.11" rev="2.1.1"/>
         <dependency org="com.datastax.spark" name="spark-cassandra-connector-unshaded_2.11" rev="2.0.2" />
     </dependencies>

--- a/images/connectors/files/ivy.xml
+++ b/images/connectors/files/ivy.xml
@@ -4,6 +4,6 @@
     <dependencies>
         <dependency org="org.elasticsearch" name="elasticsearch-spark-20_2.11" rev="5.1.1" />
         <dependency org="org.apache.spark" name="spark-streaming-kafka-0-10_2.11" rev="2.1.1"/>
-        <dependency org="com.datastax.spark" name="spark-cassandra-connector-unshaded_2.11" rev="2.0.0-M3" />
+        <dependency org="com.datastax.spark" name="spark-cassandra-connector-unshaded_2.11" rev="2.0.2" />
     </dependencies>
 </ivy-module>

--- a/images/connectors/files/ivy.xml
+++ b/images/connectors/files/ivy.xml
@@ -3,7 +3,7 @@
     <configurations defaultconfmapping="default"/>
     <dependencies>
         <dependency org="org.elasticsearch" name="elasticsearch-spark-20_2.11" rev="5.1.1" />
-        <dependency org="org.apache.spark" name="spark-streaming-kafka-0-10_2.11" rev="2.1.0"/>
+        <dependency org="org.apache.spark" name="spark-streaming-kafka-0-10_2.11" rev="2.1.1"/>
         <dependency org="com.datastax.spark" name="spark-cassandra-connector-unshaded_2.11" rev="2.0.0-M3" />
     </dependencies>
 </ivy-module>


### PR DESCRIPTION
* Elastic Search 5.X connector disable for incompatibility reasons.
* Cassandra Connector bump to 2.0.2 version.