### PR TITLE
Elastic search connector enabled and bump to 5.6.4 version

### DIFF
--- a/images/connectors/Dockerfile
+++ b/images/connectors/Dockerfile
@@ -7,4 +7,19 @@ RUN mkdir -p /usr/lib/spark/third
 ADD files/ivy.xml files/ivy-settings.xml /usr/lib/spark/third/
 RUN java -jar /usr/share/java/ivy.jar -settings /usr/lib/spark/third/ivy-settings.xml -ivy /usr/lib/spark/third/ivy.xml -retrieve "/usr/lib/spark/third/[artifact].[ext]"
 
+ENV ES_CONNECTOR_VERSION 5.6.4
+# Elastic search connector now is extracted from zip
+RUN curl \
+    -sLo /tmp/elasticsearch-hadoop-${ES_CONNECTOR_VERSION}.zip \
+    http://download.elastic.co/hadoop/elasticsearch-hadoop-${ES_CONNECTOR_VERSION}.zip \
+  && unzip \
+    /tmp/elasticsearch-hadoop-${ES_CONNECTOR_VERSION}.zip \
+    -d /tmp \
+  && cp \
+    -v \
+    /tmp/elasticsearch-hadoop-${ES_CONNECTOR_VERSION}/dist/elasticsearch-spark-20_2.11-${ES_CONNECTOR_VERSION}.jar \
+    /usr/lib/spark/third/ \
+  && rm -fr \
+    /tmp/elasticsearch-hadoop-${ES_CONNECTOR_VERSION}/*
+
 ADD files/spark-defaults.conf /usr/lib/spark/conf/

--- a/images/connectors/files/ivy.xml
+++ b/images/connectors/files/ivy.xml
@@ -2,8 +2,6 @@
     <info organisation="com.ericsson.ivi" module="jobserver-deps"/>
     <configurations defaultconfmapping="default"/>
     <dependencies>
-        <!-- Elastic search connector is not compatible with spark 2.1.1 -->
-        <!-- dependency org="org.elasticsearch" name="elasticsearch-spark-20_2.11" rev="5.1.1" / -->
         <dependency org="org.apache.spark" name="spark-streaming-kafka-0-10_2.11" rev="2.1.1"/>
         <dependency org="com.datastax.spark" name="spark-cassandra-connector-unshaded_2.11" rev="2.0.2" />
     </dependencies>


### PR DESCRIPTION
Elastic Search connector now is isntalled from zip.
ES connector version up to 5.6.4